### PR TITLE
Downgraded Ubuntu to 18.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-test:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-and-test:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Checkout
@@ -28,7 +28,7 @@ jobs:
 
     needs: build-and-test
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Getting errors with LibGit2Sharp and this suggested it doesn't support beyond 18.04: https://github.com/libgit2/libgit2sharp/issues/1703#issuecomment-563985909